### PR TITLE
Koa Routes Setup and Demo

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@koa/cors": "4.0.0",
+        "@koa/router": "12.0.0",
         "@prisma/client": "4.11.0",
+        "@types/koa__router": "12.0.0",
         "dotenv": "16.0.3",
         "koa": "2.14.1",
         "koa-body": "6.0.1",
@@ -27,7 +29,7 @@
         "eslint-config-airbnb-typescript": "17.0.0",
         "eslint-config-prettier": "8.7.0",
         "eslint-plugin-import": "2.27.5",
-        "nodemon": "^2.0.21",
+        "nodemon": "2.0.21",
         "prettier": "2.8.4",
         "ts-node-dev": "2.0.0",
         "typescript": "5.0.2"
@@ -168,6 +170,43 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@koa/router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.0.tgz",
+      "integrity": "sha512-cnnxeKHXlt7XARJptflGURdJaO+ITpNkOHmQu7NHmCoRinPbyvFzce/EG/E8Zy81yQ1W9MoSdtklc3nyaDReUw==",
+      "dependencies": {
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@koa/router/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@koa/router/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -386,6 +425,14 @@
       "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-4.0.0.tgz",
       "integrity": "sha512-qpwswNgQ2GxiDGNnKbDSBY5XmQTVJ6fspNvInLsAJ+jSwINxihvVzblj5anujNBg2BtL0xpUrcIt3UYwGzu05A==",
       "dev": true,
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa__router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.0.tgz",
+      "integrity": "sha512-S6eHyZyoWCZLNHyy8j0sMW85cPrpByCbGGU2/BO4IzGiI87aHJ92lZh4E9xfsM9DcbCT469/OIqyC0sSJXSIBQ==",
       "dependencies": {
         "@types/koa": "*"
       }
@@ -2680,6 +2727,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -3050,6 +3105,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4078,6 +4138,36 @@
         "vary": "^1.1.2"
       }
     },
+    "@koa/router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.0.tgz",
+      "integrity": "sha512-cnnxeKHXlt7XARJptflGURdJaO+ITpNkOHmQu7NHmCoRinPbyvFzce/EG/E8Zy81yQ1W9MoSdtklc3nyaDReUw==",
+      "requires": {
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4272,6 +4362,14 @@
       "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-4.0.0.tgz",
       "integrity": "sha512-qpwswNgQ2GxiDGNnKbDSBY5XmQTVJ6fspNvInLsAJ+jSwINxihvVzblj5anujNBg2BtL0xpUrcIt3UYwGzu05A==",
       "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa__router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.0.tgz",
+      "integrity": "sha512-S6eHyZyoWCZLNHyy8j0sMW85cPrpByCbGGU2/BO4IzGiI87aHJ92lZh4E9xfsM9DcbCT469/OIqyC0sSJXSIBQ==",
       "requires": {
         "@types/koa": "*"
       }
@@ -5951,6 +6049,11 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -6217,6 +6320,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/back/package.json
+++ b/back/package.json
@@ -24,14 +24,16 @@
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.7.0",
     "eslint-plugin-import": "2.27.5",
-    "nodemon": "^2.0.21",
+    "nodemon": "2.0.21",
     "prettier": "2.8.4",
     "ts-node-dev": "2.0.0",
     "typescript": "5.0.2"
   },
   "dependencies": {
     "@koa/cors": "4.0.0",
+    "@koa/router": "12.0.0",
     "@prisma/client": "4.11.0",
+    "@types/koa__router": "12.0.0",
     "dotenv": "16.0.3",
     "koa": "2.14.1",
     "koa-body": "6.0.1",

--- a/back/src/controllers/auth.controller.ts
+++ b/back/src/controllers/auth.controller.ts
@@ -1,0 +1,16 @@
+import { Middleware } from "koa"
+
+
+// TODO: specify types
+export const login : Middleware = (ctx: any, next: any) => {
+    //TODO
+}
+
+// TODO: specify types
+export const register : Middleware = (ctx: any, next: any) => {
+    //TODO
+}
+
+export const demo : Middleware = (ctx: any, next: any) => {
+    ctx.body =  "<h1>Koa Demo Is Working!</h1>"
+}

--- a/back/src/routes/auth.router.ts
+++ b/back/src/routes/auth.router.ts
@@ -1,0 +1,13 @@
+import Router from '@koa/router';
+import {login, register, demo} from '../controllers/auth.controller';
+
+const router = new Router({
+  prefix: '/auth'
+});
+
+router.get('/demo', demo)
+
+router.post('/login', login);
+router.post('/register', register);
+
+export default router

--- a/back/src/routes/index.ts
+++ b/back/src/routes/index.ts
@@ -1,0 +1,11 @@
+import Router from '@koa/router';
+
+import authRouter from './auth.router';
+//...
+
+const router = new Router();
+
+router.use(authRouter.routes(), authRouter.allowedMethods())
+//...
+
+export default router 

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -2,6 +2,7 @@ import * as dotenv from 'dotenv' // see https://github.com/motdotla/dotenv#how-d
 import Koa from 'koa'
 import cors from '@koa/cors'
 import helmet from 'koa-helmet'
+import router from './routes'
 import { HttpMethodEnum, koaBody } from 'koa-body'
 import { appConfig } from './config/config'
 import { errorMiddleware } from './middleware'
@@ -23,6 +24,8 @@ app.use(
   })
 )
 app.use(errorMiddleware)
+app.use(router.routes())
+app.use(router.allowedMethods())
 
 app.listen(appConfig.port, () => {
   console.log(`🚀 Server ready at http://localhost:${appConfig.port}`)


### PR DESCRIPTION
To try it out:

- `cd backend`
- `npm i`
- `npm run dev`
- access `localhost:8999/auth/demo` (on a web browser)

On this commit:
- Koa router installed
- `/backend/routes/auth.router.ts` created
- `/backend/controllers/auth.controller.ts` created
- `/backend/routes/index` created to aggregate routes
- Routes index imported and used by app at server.ts
