### PR TITLE
354-be-improve-getResources-response

### DIFF
--- a/back/src/__tests__/resources/get.test.ts
+++ b/back/src/__tests__/resources/get.test.ts
@@ -41,8 +41,8 @@ describe('Testing resources GET endpoint', () => {
         .get(`${pathRoot.v1.resources}`)
         .query({ resourceType })
       expect(response.status).toBe(200)
-      expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-      response.body.resources.forEach((resource: ResourceWithTopics) => {
+      expect(response.body.length).toBeGreaterThanOrEqual(1)
+      response.body.forEach((resource: ResourceWithTopics) => {
         expect(() => resourceGetSchema.parse(resource)).not.toThrow()
         expect(resource.resourceType).toBe(`${resourceType}`)
       })
@@ -62,8 +62,8 @@ describe('Testing resources GET endpoint', () => {
       .query({ topic: topicName })
 
     expect(response.status).toBe(200)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: ResourceWithTopics) => {
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: ResourceWithTopics) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
       expect(
         resource.topics.map((t: { topic: Topic }) => t.topic.name)
@@ -77,7 +77,7 @@ describe('Testing resources GET endpoint', () => {
       .query({ topic: topicName })
 
     expect(response.status).toBe(200)
-    expect(response.body.resources.length).toBe(0)
+    expect(response.body.length).toBe(0)
   })
   it('should get all resources by category slug', async () => {
     const categorySlug = 'testing'
@@ -86,8 +86,8 @@ describe('Testing resources GET endpoint', () => {
       .query({ category: categorySlug })
 
     expect(response.status).toBe(200)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: ResourceWithTopics) => {
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: ResourceWithTopics) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
       // The returned resource has at least a topic related to the queried category
       expect(
@@ -115,8 +115,8 @@ describe('Testing resources GET endpoint', () => {
         })
 
       expect(response.status).toBe(200)
-      expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-      response.body.resources.forEach((resource: ResourceWithTopics) => {
+      expect(response.body.length).toBeGreaterThanOrEqual(1)
+      response.body.forEach((resource: ResourceWithTopics) => {
         expect(() => resourceGetSchema.parse(resource)).not.toThrow()
         expect(
           resource.topics.map((t: { topic: Topic }) => t.topic.name)
@@ -140,8 +140,8 @@ describe('Testing resources GET endpoint', () => {
       .get(`${pathRoot.v1.resources}`)
       .query({ status: 'SEEN' })
     expect(response.status).toBe(200)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: ResourceWithTopics) => {
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: ResourceWithTopics) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
       expect(resource.status).toBe('SEEN')
     })
@@ -152,12 +152,12 @@ describe('Testing resources GET endpoint', () => {
       .query({})
 
     expect(response.status).toBe(200)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: ResourceWithTopics) => {
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: ResourceWithTopics) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
     })
     // All existing resources are fetched
     const countResources = await prisma.resource.count()
-    expect(response.body.resources.length).toBe(countResources)
+    expect(response.body.length).toBe(countResources)
   })
 })

--- a/back/src/controllers/resources/getResourcesController.ts
+++ b/back/src/controllers/resources/getResourcesController.ts
@@ -49,8 +49,10 @@ export const getResources: Middleware = async (ctx: Koa.Context) => {
   const parsedResources = resources.map((resource) => {
     const resourceWithVote = addVoteCountToResource(resource)
     // return parsed values to: 1. make sure it returns what we say it returns 2. delete private fields like userId
+
     return resourceGetSchema.parse(resourceWithVote)
   })
+
   ctx.status = 200
-  ctx.body = { resources: parsedResources }
+  ctx.body = parsedResources
 }


### PR DESCRIPTION
Buenas, de momento sólo tiene la mejora de suprimir la key resource.
Pero a la hora de quitar la key "topic" nos da bastantes más problemas, queda pendiente.
Pregunta, para casos así es mejor crear una "draft" PR o siempre PR normal?