### PR TITLE
522-febug-consistent-add-button-behavior-across-devices

### DIFF
--- a/front/src/components/organisms/Navbar.tsx
+++ b/front/src/components/organisms/Navbar.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react'
+import { useAuth } from '../../context/AuthProvider'
+import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { FlexBox, colors, device, dimensions } from '../../styles'
 import { Button, Icon, Title, HamburgerMenu } from '../atoms'
 import { UserButton } from '../molecules/UserButton'
 import { SelectLanguage } from '../molecules/SelectLanguage'
 import { CategoriesList } from './CategoriesList'
-import { Modal } from '../molecules/Modal'
+import { AccessModalContent, Modal } from '../molecules'
+import { Login, Register } from '../organisms'
 import { SettingsManager } from './SettingsManager'
 
 const NavbarStyled = styled(FlexBox)`
@@ -72,12 +75,32 @@ type TNavbar = {
   toggleModal?: () => void
 }
 export const Navbar = ({ toggleModal }: TNavbar) => {
+  const { user } = useAuth()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [showAccessModal, setShowAccessModal] = useState(false)
+  const [isAccessModalOpen, setIsAccessModalOpen] = useState(false)
+  const [isRegisterOpen, setIsRegisterOpen] = useState(false)
+  const [isLoginOpen, setIsLoginOpen] = useState(false)
+  const location = useLocation()
 
   const handleSettingsModal = () => {
     setIsSettingsOpen(!isSettingsOpen)
   }
+
+  const handleAccessModal = () => {
+    setIsAccessModalOpen(!isAccessModalOpen)
+  }
+
+  const handleRegisterModal = () => {
+    setIsRegisterOpen(!isRegisterOpen)
+  }
+
+  const handleLoginModal = () => {
+    setIsLoginOpen(!isLoginOpen)
+  }
+
+  const shouldRenderIcons = location.pathname !== '/'
 
   return (
     <>
@@ -87,6 +110,7 @@ export const Navbar = ({ toggleModal }: TNavbar) => {
           onClick={() => setIsMenuOpen(!isMenuOpen)}
           data-testid="hamburger-menu"
         />
+        {user && shouldRenderIcons && (
         <IconStyled
           data-testid="new-post-button"
           onClick={toggleModal}
@@ -95,6 +119,20 @@ export const Navbar = ({ toggleModal }: TNavbar) => {
         >
           <Icon name="add" color={colors.gray.gray3} />
         </IconStyled>
+        )}
+        {!user && shouldRenderIcons && (
+          <IconStyled
+            data-testid="access-modal-button"
+            onClick={() => {
+              setShowAccessModal(true);
+              handleAccessModal();
+            }}
+            title="Acceso restringido"
+            role="button"
+          >
+            <Icon name="lock" color={colors.gray.gray3} />
+          </IconStyled>
+        )}
         <SelectLanguage />
         <IconStyled
           data-testid="settings-button"
@@ -110,19 +148,46 @@ export const Navbar = ({ toggleModal }: TNavbar) => {
         </MenuItems>
       </NavbarStyled>
       <Modal
-        title="Ajustes"
-        isOpen={isSettingsOpen}
-        toggleModal={() => setIsSettingsOpen(false)}
-      >
-        {isSettingsOpen && <SettingsManager />}
-        <FlexBox>
-          <StyledButton onClick={() => setIsSettingsOpen(false)}>
-            Cerrar
-          </StyledButton>
-        </FlexBox>
+      title="Ajustes"
+      isOpen={isSettingsOpen}
+      toggleModal={() => setIsSettingsOpen(false)}
+    >
+      {isSettingsOpen && <SettingsManager />}
+      <FlexBox>
+        <StyledButton onClick={() => setIsSettingsOpen(false)}>
+          Cerrar
+        </StyledButton>
+      </FlexBox>
+    </Modal>
+    {showAccessModal && (
+      <Modal isOpen={isAccessModalOpen} toggleModal={handleAccessModal}>
+        <AccessModalContent
+          handleLoginModal={handleLoginModal}
+          handleRegisterModal={handleRegisterModal}
+          handleAccessModal={handleAccessModal}
+        />
       </Modal>
-    </>
-  )
-}
+    )}
+    <Modal
+      isOpen={isLoginOpen || isRegisterOpen}
+      toggleModal={() =>
+        isLoginOpen ? setIsLoginOpen(false) : setIsRegisterOpen(false)
+      }
+    >
+      {isLoginOpen && (
+        <Login
+          handleLoginModal={handleLoginModal}
+          handleRegisterModal={handleRegisterModal}
+        />
+      )}
+      {isRegisterOpen && (
+        <Register
+          handleLoginModal={handleLoginModal}
+          handleRegisterModal={handleRegisterModal}
+        />
+      )}
+    </Modal>
+  </>
+)};
 
 export default styled(Navbar)``


### PR DESCRIPTION
Fix Resource inconsistencies across devices:

1. The "add resource button" does not appear on the Home screen anymore.
2. The "add resource button" shows up if the user is registered and logged into their account. If that is not the case, a "lock icon" appears instead.
3. The "lock icon" effectively triggers the "Acceso restringido" modal, inviting new users to register or log into their accounts to participate in the platform.
4. Registered users will still visualise the "+" button, no matter the device they are using.