### PR TITLE
522-fe-bug-consistent-add-button-behavior

### DIFF
--- a/front/src/__tests__/organisms/Navbar.test.tsx
+++ b/front/src/__tests__/organisms/Navbar.test.tsx
@@ -20,12 +20,36 @@ describe('Navbar', () => {
 
     const settingsButton = screen.getByTestId('settings-button')
     fireEvent.click(settingsButton)
-  });
+  })
 
-  it('does not render new-post-button', () => {
-    render(<Navbar />);
+  it('renders and changes language using the language dropdown in the Navbar', () => {
+    render(<Navbar />)
   
-    const newPostButton = screen.queryByTestId('new-post-button');
-    expect(newPostButton).not.toBeInTheDocument();
-  });
+    expect(screen.getByText('CAT')).toBeInTheDocument()
+  
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'es' } })
+  
+    expect(screen.getByText('ES')).toBeInTheDocument()
+  })
+
+  it('does not render new-post-button nor access-modal on Homepage', () => {
+    window.history.pushState({}, 'Home Page', '/')
+    render(<Navbar />)
+  
+    const newPostButton = screen.queryByTestId('new-post-button')
+    expect(newPostButton).not.toBeInTheDocument()
+
+    const accessModal = screen.queryByTestId('access-modal')
+    expect(accessModal).not.toBeInTheDocument()
+
+    window.history.pushState({}, 'Original Page', '/')
+  })
+
+  it('renders the Navbar items on pages other than Homepage', () => {
+    window.history.pushState({}, 'Category Page', '/category/react')
+    render(<Navbar />)
+    
+    const menuItems = screen.queryAllByRole('button')
+    expect(menuItems.length).toBeGreaterThan(0)
+  })
 })

--- a/front/src/__tests__/organisms/Navbar.test.tsx
+++ b/front/src/__tests__/organisms/Navbar.test.tsx
@@ -1,10 +1,8 @@
-import { useLocation } from 'react-router-dom'
 import { Navbar } from '../../components/organisms/Navbar'
 import { render, screen, fireEvent } from '../test-utils'
 
 describe('Navbar', () => {
   it('renders Navbar component', () => {
-    const location = useLocation();
     render(<Navbar />)
 
     const menuButton = screen.getByTestId('hamburger-menu')
@@ -20,13 +18,14 @@ describe('Navbar', () => {
     fireEvent.click(menuButton)
     expect(menuItems).toHaveStyle('transform: translateX(-100%)')
 
-    if (location.pathname !== '/') {
-      const newPostButton = screen.getByTestId('new-post-button');
-      expect(newPostButton).toBeInTheDocument();
-      fireEvent.click(newPostButton);
-    }
-
     const settingsButton = screen.getByTestId('settings-button')
     fireEvent.click(settingsButton)
-  })
+  });
+
+  it('does not render new-post-button', () => {
+    render(<Navbar />);
+  
+    const newPostButton = screen.queryByTestId('new-post-button');
+    expect(newPostButton).not.toBeInTheDocument();
+  });
 })

--- a/front/src/__tests__/organisms/Navbar.test.tsx
+++ b/front/src/__tests__/organisms/Navbar.test.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from '../../components/organisms/Navbar'
 import { render, screen, fireEvent } from '../test-utils'
+import { useLocation } from 'react-router-dom'
 
 describe('Navbar', () => {
   it('renders Navbar component', () => {
@@ -18,9 +19,11 @@ describe('Navbar', () => {
     fireEvent.click(menuButton)
     expect(menuItems).toHaveStyle('transform: translateX(-100%)')
 
-    const newPostButton = screen.getByTestId('new-post-button')
-    expect(newPostButton).toBeInTheDocument()
-    fireEvent.click(newPostButton)
+    if (location.pathname !== '/') {
+      const newPostButton = screen.getByTestId('new-post-button');
+      expect(newPostButton).toBeInTheDocument();
+      fireEvent.click(newPostButton);
+    }
 
     const settingsButton = screen.getByTestId('settings-button')
     fireEvent.click(settingsButton)

--- a/front/src/__tests__/organisms/Navbar.test.tsx
+++ b/front/src/__tests__/organisms/Navbar.test.tsx
@@ -1,9 +1,10 @@
+import { useLocation } from 'react-router-dom'
 import { Navbar } from '../../components/organisms/Navbar'
 import { render, screen, fireEvent } from '../test-utils'
-import { useLocation } from 'react-router-dom'
 
 describe('Navbar', () => {
   it('renders Navbar component', () => {
+    const location = useLocation();
     render(<Navbar />)
 
     const menuButton = screen.getByTestId('hamburger-menu')

--- a/front/src/__tests__/organisms/Navbar.test.tsx
+++ b/front/src/__tests__/organisms/Navbar.test.tsx
@@ -1,7 +1,40 @@
+import { expect, vi } from 'vitest'
 import { Navbar } from '../../components/organisms/Navbar'
 import { render, screen, fireEvent } from '../test-utils'
+import { TAuthContext, useAuth } from '../../context/AuthProvider'
+
+vi.mock('react-router-dom', async () => {
+  const actual: Record<number, unknown> = await vi.importActual(
+    'react-router-dom'
+  )
+  return {
+    ...actual,
+    useParams: () => ({ categoryId: 1 }),
+  }
+})
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: {
+      name: 'Name',
+      avatar: 'Avatar',
+    },
+  } as TAuthContext)
+})
 
 describe('Navbar', () => {
+  beforeEach(() => {
+    vi.mock('../../context/AuthProvider', async () => {
+      const actual = await vi.importActual('../../context/AuthProvider')
+      return {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        ...actual,
+        useAuth: vi.fn(),
+      }
+    })
+  })
+
   it('renders Navbar component', () => {
     render(<Navbar />)
 
@@ -22,7 +55,7 @@ describe('Navbar', () => {
     fireEvent.click(settingsButton)
   })
 
-  it('renders and changes language using the language dropdown in the Navbar', () => {
+  it('changes language using the language dropdown in the Navbar', () => {
     render(<Navbar />)
   
     expect(screen.getByText('CAT')).toBeInTheDocument()
@@ -32,7 +65,7 @@ describe('Navbar', () => {
     expect(screen.getByText('ES')).toBeInTheDocument()
   })
 
-  it('does not render new-post-button nor access-modal on Homepage', () => {
+  it('does not render new-post-button nor access-modal on the Homepage', () => {
     window.history.pushState({}, 'Home Page', '/')
     render(<Navbar />)
   
@@ -45,11 +78,57 @@ describe('Navbar', () => {
     window.history.pushState({}, 'Original Page', '/')
   })
 
-  it('renders the Navbar items on pages other than Homepage', () => {
+  it('renders Navbar items on non-homepage pages', () => {
     window.history.pushState({}, 'Category Page', '/category/react')
     render(<Navbar />)
     
     const menuItems = screen.queryAllByRole('button')
     expect(menuItems.length).toBeGreaterThan(0)
+  })
+
+  it('displays the "Añadir recursos" modal if the user is logged in', async () => {
+    const toggleModalMock = vi.fn()
+
+    render(
+      <Navbar
+        toggleModal={toggleModalMock}
+        handleAccessModal={() => {
+        }}
+      />
+    )
+
+    const { user } = useAuth()
+    if (user) {
+      toggleModalMock()
+    } else {
+      throw new Error('Access modal should not be displayed if users are registered.')
+    }
+
+    expect(toggleModalMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('displays an "Access Modal" when unregistered users attempt to add new resources', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+    } as TAuthContext)
+  
+    const toggleModalMock = vi.fn()
+    const handleAccessModalMock = vi.fn()
+  
+    render(
+      <Navbar
+        toggleModal={toggleModalMock}
+        handleAccessModal={handleAccessModalMock}
+      />
+    )
+
+    const { user } = useAuth()
+    if (!user) {
+      handleAccessModalMock()
+    } else {
+      toggleModalMock()
+    }
+
+    expect(handleAccessModalMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/front/src/__tests__/pages/Category.test.tsx
+++ b/front/src/__tests__/pages/Category.test.tsx
@@ -47,6 +47,29 @@ it('renders correctly', () => {
   expect(screen.getByText('Recursos favoritos')).toBeInTheDocument()
 })
 
+it('renders Navbar for logged in users', () => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: {
+      name: 'Name',
+      avatar: 'Avatar',
+    },
+  } as TAuthContext)
+
+  render(<Category />)
+
+  expect(screen.getByTestId('navbar')).toBeInTheDocument()
+})
+
+it('renders Navbar for unregistered users', () => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: null,
+  } as TAuthContext)
+
+  render(<Category />)
+
+  expect(screen.getByTestId('navbar')).toBeInTheDocument()
+})
+
 it('filters opens and closes correctly', () => {
   render(<Category />)
 

--- a/front/src/components/organisms/Navbar.tsx
+++ b/front/src/components/organisms/Navbar.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import styled from 'styled-components'
 import { useLocation } from 'react-router-dom'
-import { useAuth } from '../../context/AuthProvider'
 import { FlexBox, colors, device, dimensions } from '../../styles'
 import { Button, Icon, Title, HamburgerMenu } from '../atoms'
 import { UserButton } from '../molecules/UserButton'
@@ -73,9 +72,9 @@ const StyledButton = styled(Button)`
 type TNavbar = {
   toggleModal?: () => void
   handleAccessModal?: () => void
+  isUserLogged: boolean
 }
-export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
-  const { user } = useAuth()
+export const Navbar = ({ toggleModal, handleAccessModal, isUserLogged }: TNavbar) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
@@ -83,8 +82,8 @@ export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
     setIsSettingsOpen(!isSettingsOpen)
   }
 
-  const location = useLocation();
-  const shouldRenderIcons = location.pathname !== '/'
+  const location = useLocation()
+  const shouldRenderIcons = useMemo(() => location.pathname !== '/', [location])
 
   return (
     <>
@@ -98,7 +97,7 @@ export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
           <IconStyled
               data-testid="new-post-button"
               onClick={() => {
-                if (user) {
+                if (isUserLogged) {
                   toggleModal?.();
                 } else {
                   handleAccessModal?.();

--- a/front/src/components/organisms/Navbar.tsx
+++ b/front/src/components/organisms/Navbar.tsx
@@ -83,6 +83,7 @@ export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
     setIsSettingsOpen(!isSettingsOpen)
   }
 
+  const location = useLocation();
   const shouldRenderIcons = location.pathname !== '/'
 
   return (
@@ -94,8 +95,7 @@ export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
           data-testid="hamburger-menu"
         />
         {shouldRenderIcons && (
-          <>
-            <IconStyled
+          <IconStyled
               data-testid="new-post-button"
               onClick={() => {
                 if (user) {
@@ -109,7 +109,6 @@ export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
             >
               <Icon name="add" color={colors.gray.gray3} />
             </IconStyled>
-          </>
         )}
         <SelectLanguage />
         <IconStyled

--- a/front/src/components/organisms/Navbar.tsx
+++ b/front/src/components/organisms/Navbar.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import styled from 'styled-components'
+import { useLocation } from 'react-router-dom'
+import { useAuth } from '../../context/AuthProvider'
 import { FlexBox, colors, device, dimensions } from '../../styles'
 import { Button, Icon, Title, HamburgerMenu } from '../atoms'
 import { UserButton } from '../molecules/UserButton'
@@ -70,14 +72,18 @@ const StyledButton = styled(Button)`
 
 type TNavbar = {
   toggleModal?: () => void
+  handleAccessModal?: () => void
 }
-export const Navbar = ({ toggleModal }: TNavbar) => {
+export const Navbar = ({ toggleModal, handleAccessModal }: TNavbar) => {
+  const { user } = useAuth()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
   const handleSettingsModal = () => {
     setIsSettingsOpen(!isSettingsOpen)
   }
+
+  const shouldRenderIcons = location.pathname !== '/'
 
   return (
     <>
@@ -87,14 +93,24 @@ export const Navbar = ({ toggleModal }: TNavbar) => {
           onClick={() => setIsMenuOpen(!isMenuOpen)}
           data-testid="hamburger-menu"
         />
-        <IconStyled
-          data-testid="new-post-button"
-          onClick={toggleModal}
-          title="Añadir recurso"
-          role="button"
-        >
-          <Icon name="add" color={colors.gray.gray3} />
-        </IconStyled>
+        {shouldRenderIcons && (
+          <>
+            <IconStyled
+              data-testid="new-post-button"
+              onClick={() => {
+                if (user) {
+                  toggleModal?.();
+                } else {
+                  handleAccessModal?.();
+                }
+              }}
+              title="Añadir recurso"
+              role="button"
+            >
+              <Icon name="add" color={colors.gray.gray3} />
+            </IconStyled>
+          </>
+        )}
         <SelectLanguage />
         <IconStyled
           data-testid="settings-button"

--- a/front/src/pages/Category.tsx
+++ b/front/src/pages/Category.tsx
@@ -469,7 +469,7 @@ const Category: FC = () => {
       <Container direction="row" justify="flex-start" align="start">
         <DesktopSideMenu />
         <WiderContainer>
-          <Navbar toggleModal={toggleModal} />
+          <Navbar toggleModal={toggleModal} handleAccessModal={handleAccessModal} />
           <MobileTopicsContainer>
             <Title as="h2" fontWeight="bold">
               Temas

--- a/front/src/pages/Category.tsx
+++ b/front/src/pages/Category.tsx
@@ -469,7 +469,7 @@ const Category: FC = () => {
       <Container direction="row" justify="flex-start" align="start">
         <DesktopSideMenu />
         <WiderContainer>
-          <Navbar toggleModal={toggleModal} handleAccessModal={handleAccessModal} />
+          <Navbar isUserLogged={user !== null} toggleModal={toggleModal} handleAccessModal={handleAccessModal} />
           <MobileTopicsContainer>
             <Title as="h2" fontWeight="bold">
               Temas

--- a/front/src/pages/Home.tsx
+++ b/front/src/pages/Home.tsx
@@ -121,7 +121,7 @@ const Home: FC = () => {
     <Container direction="row" justify="flex-start" align="start">
       <DesktopSideMenu />
       <ContainerMain>
-        <Navbar />
+        <Navbar isUserLogged={user !== null} />
         <MainDiv
           as="main"
           justify="flex-start"


### PR DESCRIPTION
Fix Resource inconsistencies across devices:

1. The "add resource button" does not appear on the Home screen anymore.
2. The "add resource button" shows up only if the user is registered and logged into their account.
3. It effectively triggers the "Acceso restringido" modal, inviting new users to register or log into their accounts to participate in the platform.