### PR TITLE
616-be-getresourcesme-add-userid-flat-nested-array

### DIFF
--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -870,6 +870,8 @@ paths:
                     resourceType:
                       type: string
                       enum: *a2
+                    userId:
+                      type: string
                     categoryId:
                       type: string
                       example: clocr0bi20000h8vwipfbazso
@@ -956,6 +958,7 @@ paths:
                     - slug
                     - url
                     - resourceType
+                    - userId
                     - categoryId
                     - createdAt
                     - updatedAt
@@ -1168,6 +1171,8 @@ paths:
                   resourceType:
                     type: string
                     enum: *a2
+                  userId:
+                    type: string
                   categoryId:
                     type: string
                     example: clocr0bi20000h8vwipfbazso
@@ -1254,6 +1259,7 @@ paths:
                   - slug
                   - url
                   - resourceType
+                  - userId
                   - categoryId
                   - createdAt
                   - updatedAt
@@ -1346,6 +1352,8 @@ paths:
                   resourceType:
                     type: string
                     enum: *a2
+                  userId:
+                    type: string
                   categoryId:
                     type: string
                     example: clocr0bi20000h8vwipfbazso
@@ -1432,6 +1440,7 @@ paths:
                   - slug
                   - url
                   - resourceType
+                  - userId
                   - categoryId
                   - createdAt
                   - updatedAt
@@ -1452,10 +1461,19 @@ paths:
     get:
       tags:
         - resources
-      description: Returns all the posted resources by a logged in user.
       summary: Get resources by logged in user
+      description: Returns all the posted resources by a logged in user. In addition,
+        if categorySlug query provided, returns only the resources posted in
+        that category.
       security:
         - cookieAuth: []
+      parameters:
+        - in: query
+          name: categorySlug
+          schema:
+            type: string
+            example: react
+          required: false
       responses:
         "200":
           description: All resources posted by user are returned.
@@ -1488,6 +1506,8 @@ paths:
                         resourceType:
                           type: string
                           enum: *a2
+                        userId:
+                          type: string
                         categoryId:
                           type: string
                           example: clocr0bi20000h8vwipfbazso
@@ -1574,6 +1594,7 @@ paths:
                         - slug
                         - url
                         - resourceType
+                        - userId
                         - categoryId
                         - createdAt
                         - updatedAt

--- a/back/src/__tests__/resources/me.test.ts
+++ b/back/src/__tests__/resources/me.test.ts
@@ -83,8 +83,8 @@ describe('Testing resources/me endpoint', () => {
       .set('Cookie', authToken.admin)
 
     expect(response.status).toBe(200)
-    expect(response.body.resources).toBeInstanceOf(Array)
-    expect(response.body.resources.length).toBe(0)
+    expect(response.body).toBeInstanceOf(Array)
+    expect(response.body.length).toBe(0)
   })
 
   it('Should return resources from user', async () => {
@@ -94,9 +94,9 @@ describe('Testing resources/me endpoint', () => {
       .set('Cookie', authToken.user)
 
     expect(response.status).toBe(200)
-    expect(response.body.resources).toBeInstanceOf(Array)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: any) => {
+    expect(response.body).toBeInstanceOf(Array)
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: any) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
     })
   })
@@ -108,18 +108,21 @@ describe('Testing resources/me endpoint', () => {
       .set('Cookie', authToken.user)
       .query({ testCategorySlug })
     expect(response.status).toBe(200)
-    expect(response.body.resources).toBeInstanceOf(Array)
-    expect(response.body.resources.length).toBeGreaterThanOrEqual(1)
-    response.body.resources.forEach((resource: any) => {
+    expect(response.body).toBeInstanceOf(Array)
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: any) => {
       expect(() => resourceGetSchema.parse(resource)).not.toThrow()
     })
   })
 
   it('If the user voted and favorited one of its own created resources, it should be reflected on the response object', async () => {
+    const user = await prisma.user.findUnique({
+      where: { email: testUserData.user.email },
+    })
     const response = await supertest(server)
       .get(`${pathRoot.v1.resources}/me`)
       .set('Cookie', authToken.user)
-    expect(response.body.resources).toEqual(
+    expect(response.body).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           voteCount: expect.objectContaining({
@@ -129,6 +132,7 @@ describe('Testing resources/me endpoint', () => {
             userVote: 1,
           }),
           isFavorite: true,
+          userId: user!.id,
         }),
       ])
     )

--- a/back/src/controllers/resources/getResourcesByUserId.ts
+++ b/back/src/controllers/resources/getResourcesByUserId.ts
@@ -6,9 +6,9 @@ import { resourceGetSchema } from '../../schemas'
 
 export const getResourcesByUserId: Middleware = async (ctx: Koa.Context) => {
   const user = ctx.user as User
-  const categorySlug = ctx.query.categorySlug?.toString()
+  const categorySlug = ctx.query.categorySlug as string | undefined
 
-  let resources
+  let resources = []
 
   const include = {
     user: {
@@ -19,7 +19,7 @@ export const getResourcesByUserId: Middleware = async (ctx: Koa.Context) => {
     vote: { select: { vote: true, userId: true } },
     topics: { select: { topic: true } },
     favorites: {
-      where: { userId: user.id },
+      where: { userId: user ? user.id : undefined },
     },
   }
 
@@ -67,6 +67,7 @@ export const getResourcesByUserId: Middleware = async (ctx: Koa.Context) => {
   const parsedResources = resourcesWithFavorites.map((resource) =>
     resourceGetSchema.parse(transformResourceToAPI(resource, user.id))
   )
+
   ctx.status = 200
-  ctx.body = { resources: parsedResources }
+  ctx.body = parsedResources
 }

--- a/back/src/helpers/transformResourceToAPI.ts
+++ b/back/src/helpers/transformResourceToAPI.ts
@@ -66,8 +66,10 @@ export function transformResourceToAPI(
   userId?: string
 ): TResourceWithVoteCount {
   const voteCount = calculateVoteCount(resource.vote, userId)
+
   return {
     ...resource,
+    userId: resource.userId,
     voteCount,
   }
 }

--- a/back/src/openapi/routes/resources/me.ts
+++ b/back/src/openapi/routes/resources/me.ts
@@ -13,8 +13,14 @@ registry.registerPath({
   method: 'get',
   tags: ['resources'],
   path: `${pathRoot.v1.resources}/me`,
-  description: 'Returns all the posted resources by a logged in user.',
   summary: 'Get resources by logged in user',
+  description:
+    'Returns all the posted resources by a logged in user. In addition, if categorySlug query provided, returns only the resources posted in that category.',
+  request: {
+    query: z.object({
+      categorySlug: z.string().optional().openapi({ example: 'react' }),
+    }),
+  },
   security: [{ [cookieAuth.name]: [] }],
   responses: {
     200: {

--- a/back/src/schemas/resource/resourceGetSchema.ts
+++ b/back/src/schemas/resource/resourceGetSchema.ts
@@ -4,16 +4,11 @@ import { userSchema } from '../users/userSchema'
 import { voteCountSchema } from '../voteCountSchema'
 import { resourceSchema } from './resourceSchema'
 
-export const resourceGetSchema = resourceSchema
-  .omit({
-    userId: true,
-    topics: true,
-  })
-  .extend({
-    user: userSchema.pick({
-      name: true,
-    }),
-    topics: z.array(z.object({ topic: topicSchema })),
-    voteCount: voteCountSchema,
-    isFavorite: z.boolean().default(false),
-  })
+export const resourceGetSchema = resourceSchema.extend({
+  user: userSchema.pick({
+    name: true,
+  }),
+  topics: z.array(z.object({ topic: topicSchema })),
+  voteCount: voteCountSchema,
+  isFavorite: z.boolean().default(false),
+})


### PR DESCRIPTION
*Added categorySlug query param on swagger for getResources/me
*Removed nested resources array in response
*Add userId on getResources/me response --> For that I decided to include the property in the object returned by the helper function transformResourceToAPI as so:
```
export function transformResourceToAPI(
  resource: TResource,
  userId?: string
): TResourceWithVoteCount {
  const voteCount = calculateVoteCount(resource.vote, userId)

  return {
    ...resource,
    userId: resource.userId,
    voteCount,
  }
}
```
For this to work, I had to remove the .omit() block on resourceGetSchema, which was omitting topics and userId.
