### PR TITLE
589-be-implement-by-name-query-filters

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2023-11-21
+
+### Changed
+
+- Added search query param to get resources endpoint.
+
 ## [0.2.0] - 2023-11-20
 
 ### Changed

--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -841,6 +841,14 @@ paths:
                 - NOT_SEEN
           required: false
           description: Status to filter by
+        - in: query
+          name: search
+          schema:
+            type: string
+            minLength: 2
+          required: false
+          description: Search query to filter by
+          example: tailwind
       responses:
         "200":
           description: Sucessful operation
@@ -967,25 +975,11 @@ paths:
                     - voteCount
                     - isFavorite
         "400":
-          description: Validation error
+          description: Zod validation error
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/ValidationError"
-                  - example:
-                      message:
-                        - code: invalid_enum_value
-                          received: BLO
-                          options:
-                            - BLOG
-                            - VIDEO
-                            - TUTORIAL
-                          path:
-                            - query
-                            - resourceType
-                          message: Invalid enum value. Expected 'BLOG' | 'VIDEO' | 'TUTORIAL', received
-                            'BLO'
+                $ref: "#/components/schemas/ValidationError"
         "498":
           description: Invalid token
           content:

--- a/back/package.json
+++ b/back/package.json
@@ -1,7 +1,7 @@
 {
   "name": "back",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/back/src/__tests__/resources/get.test.ts
+++ b/back/src/__tests__/resources/get.test.ts
@@ -301,6 +301,18 @@ describe('Testing resources GET endpoint', () => {
       }
     })
   })
+  it('should display all resources containing a query search string in title or description', async () => {
+    const search = 'blog'
+    const response = await supertest(server)
+      .get(`${pathRoot.v1.resources}`)
+      .query({ search })
+    expect(response.status).toBe(200)
+    expect(response.body.length).toBeGreaterThanOrEqual(1)
+    response.body.forEach((resource: ResourceGetSchema) => {
+      expect(resource.title.toLowerCase()).toContain(search)
+      expect(resource.description!.toLowerCase()).toContain(search)
+    })
+  })
 
   checkInvalidToken(`${pathRoot.v1.resources}`, 'get')
 })

--- a/back/src/controllers/resources/get.ts
+++ b/back/src/controllers/resources/get.ts
@@ -7,7 +7,7 @@ import { TResourcesGetParamsSchema } from '../../schemas/resource/resourcesGetPa
 
 export const getResources: Middleware = async (ctx: Koa.Context) => {
   const user = ctx.user as User | null
-  const { resourceTypes, topics, slug, status } =
+  const { resourceTypes, topics, slug, status, search } =
     ctx.query as TResourcesGetParamsSchema
   let statusCondition: Prisma.Enumerable<Prisma.ResourceWhereInput> = {}
   if (user && status) {
@@ -26,6 +26,12 @@ export const getResources: Middleware = async (ctx: Koa.Context) => {
     },
     resourceType: { in: resourceTypes },
     ...statusCondition,
+    ...(search && {
+      OR: [
+        { title: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+      ],
+    }),
   }
   const voteSelect =
     ctx.user !== null ? { userId: true, vote: true } : { vote: true }

--- a/back/src/schemas/resource/resourcesGetParamsSchema.ts
+++ b/back/src/schemas/resource/resourcesGetParamsSchema.ts
@@ -57,6 +57,16 @@ export const resourcesGetParamsSchema = z
         },
         example: 'NOT_SEEN',
       }),
+    search: z
+      .string()
+      .min(2, 'Search query must be at least 2 characters long')
+      .optional()
+      .openapi({
+        param: {
+          description: 'Search query to filter by',
+          example: 'tailwind',
+        },
+      }),
   })
   .strict()
 


### PR DESCRIPTION
-Modified resourceGetParamsSchema.ts to admit optional query "search" param (with 2 chars min).
-Added filter by search term on GET resources "where" (case insensitve).
-Test on postman works no matter the casing.
-Added additional test on get resources to include search param.
--> Pending modifications on FE to test the functionality of search within a category.
This PR alone does NOT close the issue https://github.com/IT-Academy-BCN/ita-wiki/issues/589.