### PR TITLE
685-be-fix-resources-filter-by-topic

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2023-11-23
+
+### Changed
+
+- Modified GET resources endpoint to admit one optional topic string (topicId).
+
 ## [0.3.0] - 2023-11-21
 
 ### Changed

--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -822,13 +822,13 @@ paths:
           required: false
           description: Resource types to filter by
         - in: query
-          name: topics
+          name: topic
           schema:
-            type: array
-            items:
-              type: string
-              example: cln2u09xo0037s6wvbf6t9jfg
+            type: string
+            example: cln2u09xo0037s6wvbf6t9jfg
           required: false
+          description: ID string of the topic for which to retrieve resources. If not
+            provided, resources for ALL topics are fetched.
         - in: query
           name: status
           schema:

--- a/back/package.json
+++ b/back/package.json
@@ -1,7 +1,7 @@
 {
   "name": "back",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/back/src/__tests__/resources/get.test.ts
+++ b/back/src/__tests__/resources/get.test.ts
@@ -102,7 +102,7 @@ describe('Testing resources GET endpoint', () => {
 
     const response = await supertest(server)
       .get(`${pathRoot.v1.resources}`)
-      .query(qs.stringify({ topics: [topicId] }))
+      .query(qs.stringify({ topic: topicId }))
 
     expect(response.status).toBe(200)
     expect(response.body.length).toBeGreaterThanOrEqual(1)
@@ -114,11 +114,10 @@ describe('Testing resources GET endpoint', () => {
     })
   })
 
-  it('should fail without a valid topic name', async () => {
-    const topicName = 'This topic does not exist'
+  it('should not return any resource if non-valid topic id provided', async () => {
     const response = await supertest(server)
       .get(`${pathRoot.v1.resources}`)
-      .query(qs.stringify({ topics: [topicName] }))
+      .query(qs.stringify({ topic: 'notValidTopicId' }))
 
     expect(response.status).toBe(200)
     expect(response.body.length).toBe(0)
@@ -159,7 +158,7 @@ describe('Testing resources GET endpoint', () => {
         .get(`${pathRoot.v1.resources}`)
         .query(
           qs.stringify({
-            topics: [topicId],
+            topic: topicId,
             resourceTypes: [resourceType],
             slug: categorySlug,
           })

--- a/back/src/controllers/resources/get.ts
+++ b/back/src/controllers/resources/get.ts
@@ -7,8 +7,13 @@ import { TResourcesGetParamsSchema } from '../../schemas/resource/resourcesGetPa
 
 export const getResources: Middleware = async (ctx: Koa.Context) => {
   const user = ctx.user as User | null
-  const { resourceTypes, topics, slug, status, search } =
-    ctx.query as TResourcesGetParamsSchema
+  const {
+    resourceTypes,
+    topic: topicId,
+    slug,
+    status,
+    search,
+  } = ctx.query as TResourcesGetParamsSchema
   let statusCondition: Prisma.Enumerable<Prisma.ResourceWhereInput> = {}
   if (user && status) {
     const viewedFilter = { userId: user.id }
@@ -21,7 +26,7 @@ export const getResources: Middleware = async (ctx: Koa.Context) => {
   const where: Prisma.ResourceWhereInput = {
     topics: {
       some: {
-        topic: { category: { slug }, id: { in: topics } },
+        topic: { category: { slug }, id: topicId },
       },
     },
     resourceType: { in: resourceTypes },

--- a/back/src/schemas/resource/resourcesGetParamsSchema.ts
+++ b/back/src/schemas/resource/resourcesGetParamsSchema.ts
@@ -32,16 +32,15 @@ export const resourcesGetParamsSchema = z
         },
         example: 'BLOG',
       }),
-    topics: z
-      .array(
-        z.string().openapi({
-          param: {
-            description:
-              'Array of topic IDs for which to retrieve resources. If not provided, resources for ALL topics are fetched.',
-          },
-          example: 'cln2u09xo0037s6wvbf6t9jfg',
-        })
-      )
+    topic: z
+      .string()
+      .openapi({
+        param: {
+          description:
+            'ID string of the topic for which to retrieve resources. If not provided, resources for ALL topics are fetched.',
+        },
+        example: 'cln2u09xo0037s6wvbf6t9jfg',
+      })
       .optional(),
     status: z
       .union([statusEnum, z.array(statusEnum)])


### PR DESCRIPTION
* GET Resources endpoint now admits only ONE optional topicID string
* It will filter all resources related to the specified topicID.
* Tests, schemas and swagger updated