### PR TITLE
675-be-modify-getfavorites-response

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2023-11-28
+
+### Changed
+
+- Modified GET Favorites resources controller and schema so response omits userId and includes a "isAuthor" boolean and a user object contaning name and avatarId.
+
 ## [0.3.2] - 2023-11-23
 
 ### Changed

--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -687,8 +687,6 @@ paths:
                         - BLOG
                         - VIDEO
                         - TUTORIAL
-                    userId:
-                      type: string
                     categoryId:
                       type: string
                       example: clocr0bi20000h8vwipfbazso
@@ -702,6 +700,19 @@ paths:
                         - type: string
                           format: date-time
                         - type: string
+                    user:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        avatarId:
+                          type: string
+                          nullable: true
+                      required:
+                        - name
+                        - avatarId
+                    isAuthor:
+                      type: boolean
                     voteCount:
                       type: object
                       properties:
@@ -767,10 +778,11 @@ paths:
                     - slug
                     - url
                     - resourceType
-                    - userId
                     - categoryId
                     - createdAt
                     - updatedAt
+                    - user
+                    - isAuthor
                     - voteCount
                     - topics
         "401":

--- a/back/package.json
+++ b/back/package.json
@@ -1,7 +1,7 @@
 {
   "name": "back",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/back/src/__tests__/resources/favorites.test.ts
+++ b/back/src/__tests__/resources/favorites.test.ts
@@ -95,9 +95,19 @@ describe('Testing GET resource/favorites/:categorySlug?', () => {
           description: expect.any(String),
           url: expect.any(String),
           resourceType: expect.any(String),
-          userId: expect.any(String),
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
+          user: expect.objectContaining({
+            name: expect.any(String),
+            avatarId: null,
+          }),
+          isAuthor: expect.any(Boolean),
+          voteCount: expect.objectContaining({
+            upvote: expect.any(Number),
+            downvote: expect.any(Number),
+            total: expect.any(Number),
+            userVote: expect.any(Number),
+          }),
           topics: expect.arrayContaining([
             expect.objectContaining({
               topic: expect.objectContaining({
@@ -105,15 +115,11 @@ describe('Testing GET resource/favorites/:categorySlug?', () => {
                 name: expect.any(String),
                 slug: expect.any(String),
                 categoryId: expect.any(String),
+                createdAt: expect.any(String),
+                updatedAt: expect.any(String),
               }),
             }),
           ]),
-          voteCount: expect.objectContaining({
-            upvote: expect.any(Number),
-            downvote: expect.any(Number),
-            total: expect.any(Number),
-            userVote: expect.any(Number),
-          }),
         }),
       ])
     )

--- a/back/src/controllers/resources/getFavoriteResources.ts
+++ b/back/src/controllers/resources/getFavoriteResources.ts
@@ -6,6 +6,7 @@ import { resourceFavoriteSchema } from '../../schemas'
 
 export const getFavoriteResources: Middleware = async (ctx: Koa.Context) => {
   const user = ctx.user as User
+
   const { categorySlug } = ctx.params
   const where = {
     userId: user.id,
@@ -23,21 +24,39 @@ export const getFavoriteResources: Middleware = async (ctx: Koa.Context) => {
           description: true,
           url: true,
           resourceType: true,
+          userId: true,
           createdAt: true,
           updatedAt: true,
-          userId: true,
           categoryId: true,
           topics: { select: { topic: true } },
           vote: { select: { vote: true, userId: true } },
         },
       },
+      user: {
+        select: {
+          name: true,
+          avatarId: true,
+        },
+      },
     },
   })
 
-  const parsedResources = favorites.map((resource) =>
-    resourceFavoriteSchema.parse(
-      transformResourceToAPI(resource.resource, user ? user.id : undefined)
-    )
+  // console.log('favorites: ', favorites)
+
+  const favoritesWithIsAuthor = favorites.map((fav) => {
+    const isAuthor = fav.resource.userId === user.id
+    return { ...fav, resource: { ...fav.resource, isAuthor } }
+  })
+
+  const parsedResources = favoritesWithIsAuthor.map((resource) =>
+    resourceFavoriteSchema.parse({
+      ...transformResourceToAPI(resource.resource, user ? user.id : undefined),
+      user: {
+        name: resource.user.name,
+        avatarId: resource.user.avatarId,
+      },
+      isAuthor: resource.resource.isAuthor,
+    })
   )
 
   ctx.status = 200

--- a/back/src/helpers/transformResourceToAPI.ts
+++ b/back/src/helpers/transformResourceToAPI.ts
@@ -69,7 +69,6 @@ export function transformResourceToAPI(
 
   return {
     ...resource,
-    userId: resource.userId,
     voteCount,
   }
 }

--- a/back/src/schemas/resource/resourceFavoriteSchema.ts
+++ b/back/src/schemas/resource/resourceFavoriteSchema.ts
@@ -4,7 +4,16 @@ import { topicSchema } from '../topic/topicSchema'
 import { voteCountSchema } from '../voteCountSchema'
 import { resourceSchema } from './resourceSchema'
 
-export const resourceFavoriteSchema = resourceSchema.extend({
-  voteCount: voteCountSchema,
-  topics: z.array(z.object({ topic: topicSchema })),
-})
+export const resourceFavoriteSchema = resourceSchema
+  .omit({
+    userId: true,
+  })
+  .extend({
+    user: z.object({
+      name: z.string(),
+      avatarId: z.string().nullable(),
+    }),
+    isAuthor: z.boolean(),
+    voteCount: voteCountSchema,
+    topics: z.array(z.object({ topic: topicSchema })),
+  })


### PR DESCRIPTION
* Modified resourceFavoriteSchema.ts and controller so at the moment of parsing the response object:
userId is omitted (in resourceGetFavorites)
response includes isAuthor boolean and user object with name and avatarId are in
* Helper function transformResourceToAPI no longer adds the userId to the returned resource object.
* Now, getFavorites no longer returns userId property.
* Once the other issues, #676 and #673 are solved, GET resources and GET resources/me they will also omit the userId property in their responses.
* The new returned object for this endpoint (GET favorites) looks like this:
```json
[
    {
        "id": "clpi44ola000eh8e0rzrrlvos",
        "title": "My second resource in React",
        "slug": "my-second-resource-in-react",
        "description": "Lorem ipsum",
        "url": "http://www.example.com/resource/React2.html",
        "resourceType": "VIDEO",
        "categoryId": "clpi44odu0000h8e0rtlo6t9y",
        "createdAt": "2023-11-28T09:05:32.542Z",
        "updatedAt": "2023-11-28T09:05:32.542Z",
        "user": {
            "name": "Kevin Mamaqi",
            "avatarId": null
        },
        "isAuthor": false,
        "voteCount": {
            "upvote": 0,
            "downvote": 0,
            "total": 0,
            "userVote": 0
        },
        "topics": [
            {
                "topic": {
                    "id": "clpi44ol1000ah8e0azfg0keq",
                    "name": "Listas",
                    "slug": "listas",
                    "categoryId": "clpi44odu0000h8e0rtlo6t9y",
                    "createdAt": "2023-11-28T09:05:32.533Z",
                    "updatedAt": "2023-11-28T09:05:32.533Z"
                }
            }
        ]
    }
]
```