### PR TITLE
734-be-modify-nested-user-in-getfavorites

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2023-11-29
+
+### Changed
+
+- Modified GET Favorites query so the nested user object returned with each favorite resource, specifies the name and avatarId of the author of each resource.
+
 ## [0.3.3] - 2023-11-28
 
 ### Changed

--- a/back/package.json
+++ b/back/package.json
@@ -1,7 +1,7 @@
 {
   "name": "back",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/back/src/controllers/resources/getFavoriteResources.ts
+++ b/back/src/controllers/resources/getFavoriteResources.ts
@@ -30,18 +30,16 @@ export const getFavoriteResources: Middleware = async (ctx: Koa.Context) => {
           categoryId: true,
           topics: { select: { topic: true } },
           vote: { select: { vote: true, userId: true } },
-        },
-      },
-      user: {
-        select: {
-          name: true,
-          avatarId: true,
+          user: {
+            select: {
+              name: true,
+              avatarId: true,
+            },
+          },
         },
       },
     },
   })
-
-  // console.log('favorites: ', favorites)
 
   const favoritesWithIsAuthor = favorites.map((fav) => {
     const isAuthor = fav.resource.userId === user.id
@@ -51,10 +49,6 @@ export const getFavoriteResources: Middleware = async (ctx: Koa.Context) => {
   const parsedResources = favoritesWithIsAuthor.map((resource) =>
     resourceFavoriteSchema.parse({
       ...transformResourceToAPI(resource.resource, user ? user.id : undefined),
-      user: {
-        name: resource.user.name,
-        avatarId: resource.user.avatarId,
-      },
       isAuthor: resource.resource.isAuthor,
     })
   )


### PR DESCRIPTION
* This PR takes it from this one: https://github.com/IT-Academy-BCN/ita-wiki/pull/716
* Modified GET Favorites query so the nested user object returned with each favorite resource, specifies the name and avatarId of the author of each resource. Before, the nested user object corresponded to the one who marked the resource as favorite.
* Added a test to check that if a favorite resource is authored by the connected user then it is reflected in isAuthor and in his/her name in the nested user object.
```json
[
    {
        "id": "clpjuf9aw000fh85wrtffeel4",
        "title": "My resource in Javascript",
        "slug": "my-resource-in-javascript",
        "description": "Lorem ipsum",
        "url": "http://www.example.com/resource/Javascript.html",
        "resourceType": "TUTORIAL",
        "categoryId": "clpjuf8vy0001h85wq2ckcpzj",
        "createdAt": "2023-11-29T14:09:22.136Z",
        "updatedAt": "2023-11-29T14:09:22.136Z",
        "user": {
            "name": "Django Unchained",
            "avatarId": null
        },
        "isAuthor": false,
        "voteCount": {
            "upvote": 0,
            "downvote": 0,
            "total": 0,
            "userVote": 0
        },
        "topics": [
            {
                "topic": {
                    "id": "clpjuf9ah000bh85wwhjixdda",
                    "name": "Estilos",
                    "slug": "estilos",
                    "categoryId": "clpjuf8vy0001h85wq2ckcpzj",
                    "createdAt": "2023-11-29T14:09:22.121Z",
                    "updatedAt": "2023-11-29T14:09:22.121Z"
                }
            }
        ]
    },
]
```
